### PR TITLE
Various cleanup things

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-madsonic-server-5.0
+madsonic-server
 ===================
 
-Madsonic Server 5.0 Build 3840
+Madsonic Server 

--- a/madsonic-installer-debian/src/DEBIAN/control
+++ b/madsonic-installer-debian/src/DEBIAN/control
@@ -2,6 +2,7 @@ Package: madsonic
 Version: @VERSION@
 Section: Multimedia
 Priority: optional
+Depends: default-jre-headless | default-jre
 Recommends: lame, ffmpeg, xmp
 Architecture: all
 Maintainer: Madevil <madevil@madsonic.org>

--- a/madsonic-installer-debian/src/etc/default/madsonic
+++ b/madsonic-installer-debian/src/etc/default/madsonic
@@ -3,7 +3,7 @@
 # (/etc/init.d/madsonic)
 #
 # To change the startup parameters of Madsonic, modify
-# the SUBSONIC_ARGS variable below.
+# the MADSONIC_ARGS variable below.
 #
 # Type "madsonic --help" on the command line to read an
 # explanation of the different options.
@@ -12,9 +12,9 @@
 # and 443 (for https), and use a Java memory heap size of 350 MB, use
 # the following:
 #
-# SUBSONIC_ARGS="--port=80 --https-port=443 --max-memory=350"
+# MADSONIC_ARGS="--port=80 --https-port=443 --max-memory=350"
 
-SUBSONIC_ARGS="--init-memory=200 --max-memory=350"
+MADSONIC_ARGS="--init-memory=200 --max-memory=350"
 
 
 # The user which should run the Madsonic process. Default "root".
@@ -22,4 +22,4 @@ SUBSONIC_ARGS="--init-memory=200 --max-memory=350"
 # below 1024. Also make sure to grant the user write permissions in
 # the music directories, otherwise changing album art and tags will fail.
 
-SUBSONIC_USER=root
+MADSONIC_USER=root

--- a/madsonic-installer-debian/src/etc/init.d/madsonic
+++ b/madsonic-installer-debian/src/etc/init.d/madsonic
@@ -22,14 +22,14 @@ DESC="Madsonic Daemon"
 NAME=madsonic
 PIDFILE=/var/run/$NAME.pid
 DAEMON=/usr/bin/$NAME
-DAEMON_ARGS="--pidfile=$PIDFILE $SUBSONIC_ARGS"
+DAEMON_ARGS="--pidfile=$PIDFILE $MADSONIC_ARGS"
 SCRIPTNAME=/etc/init.d/$NAME
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
 
-# Run as root if SUBSONIC_USER is not set.
-[ "$SUBSONIC_USER" = "" ] && SUBSONIC_USER=root
+# Run as root if MADSONIC_USER is not set.
+[ "$MADSONIC_USER" = "" ] && MADSONIC_USER=root
 
 # Make sure madsonic is started with system locale
 if [ -r /etc/default/locale ]; then
@@ -61,11 +61,11 @@ do_start()
     fi
 
     touch $PIDFILE
-    chown $SUBSONIC_USER $PIDFILE
-    [ -e /var/madsonic ] && chown -R $SUBSONIC_USER /var/madsonic
-    [ -e /tmp/madsonic ] && chown -R $SUBSONIC_USER /tmp/madsonic
+    chown $MADSONIC_USER $PIDFILE
+    [ -e /var/madsonic ] && chown -R $MADSONIC_USER /var/madsonic
+    [ -e /tmp/madsonic ] && chown -R $MADSONIC_USER /tmp/madsonic
 
-    start-stop-daemon --start -c $SUBSONIC_USER --pidfile $PIDFILE --exec $DAEMON -- $DAEMON_ARGS || return 2
+    start-stop-daemon --start -c $MADSONIC_USER --pidfile $PIDFILE --exec $DAEMON -- $DAEMON_ARGS || return 2
 }
 
 #

--- a/madsonic-installer-rpm/src/etc/init.d/madsonic
+++ b/madsonic-installer-rpm/src/etc/init.d/madsonic
@@ -28,14 +28,14 @@ NAME=madsonic
 PIDFILE=/var/run/$NAME.pid
 LOCKFILE=/var/lock/subsys/$NAME
 DAEMON=/usr/bin/$NAME
-DAEMON_ARGS="--pidfile=$PIDFILE $SUBSONIC_ARGS"
+DAEMON_ARGS="--pidfile=$PIDFILE $MADSONIC_ARGS"
 SCRIPTNAME=/etc/init.d/$NAME
 
 # Exit if the package is not installed.
 [ -x "$DAEMON" ] || exit 0
 
-# Run as root if SUBSONIC_USER is not set.
-[ "$SUBSONIC_USER" = "" ] && SUBSONIC_USER=root
+# Run as root if MADSONIC_USER is not set.
+[ "$MADSONIC_USER" = "" ] && MADSONIC_USER=root
 
 # Source function library.
 . /etc/init.d/functions
@@ -53,12 +53,12 @@ do_start()
     fi
 
     touch $PIDFILE
-    chown $SUBSONIC_USER $PIDFILE
-    [ -e /var/madsonic ] && chown -R $SUBSONIC_USER /var/madsonic
-    [ -e /tmp/madsonic ] && chown -R $SUBSONIC_USER /tmp/madsonic
+    chown $MADSONIC_USER $PIDFILE
+    [ -e /var/madsonic ] && chown -R $MADSONIC_USER /var/madsonic
+    [ -e /tmp/madsonic ] && chown -R $MADSONIC_USER /tmp/madsonic
 
     echo $"Starting $NAME ..."
-    su -c "$DAEMON $DAEMON_ARGS" $SUBSONIC_USER
+    su -c "$DAEMON $DAEMON_ARGS" $MADSONIC_USER
     RETVAL=$?
     echo
     [ $RETVAL -eq 0 ] && touch $LOCKFILE

--- a/madsonic-installer-rpm/src/etc/sysconfig/madsonic
+++ b/madsonic-installer-rpm/src/etc/sysconfig/madsonic
@@ -3,7 +3,7 @@
 # (/etc/init.d/madsonic)
 #
 # To change the startup parameters of Madsonic, modify
-# the SUBSONIC_ARGS variable below.
+# the MADSONIC_ARGS variable below.
 #
 # Type "madsonic --help" on the command line to read an
 # explanation of the different options.
@@ -12,9 +12,9 @@
 # and 443 (for https), and use a Java memory heap size of 350 MB, use
 # the following:
 #
-# SUBSONIC_ARGS="--port=80 --https-port=443 --max-memory=350"
+# MADSONIC_ARGS="--port=80 --https-port=443 --max-memory=350"
 
-SUBSONIC_ARGS="--init-memory=200 --max-memory=350"
+MADSONIC_ARGS="--init-memory=200 --max-memory=350"
 
 
 # The user which should run the Madsonic process. Default "root".
@@ -22,4 +22,4 @@ SUBSONIC_ARGS="--init-memory=200 --max-memory=350"
 # below 1024. Also make sure to grant the user write permissions in
 # the music directories, otherwise changing album art and tags will fail.
 
-SUBSONIC_USER=root
+MADSONIC_USER=root


### PR DESCRIPTION
Cleans up the deb and rpm init scripts to remove subsonic references. 
Corrects the deb installer to require a JRE be installed with the package.
Sets the README up so 5.1 can exist in the same repo as 5.0.
