### PR TITLE
Update rpm pom.xml to include latest version number.

### DIFF
--- a/madsonic-installer-rpm/pom.xml
+++ b/madsonic-installer-rpm/pom.xml
@@ -63,7 +63,7 @@
                                               todir="${project.build.directory}/rpm/SPECS">
                                             <filterset>
                                                 <filter token="VERSION" value="${project.version}"/>
-                                                <filter token="BUILD_NUMBER" value="3830"/>
+                                                <filter token="BUILD_NUMBER" value="3880"/>
                                             </filterset>
                                         </copy>
 


### PR DESCRIPTION
Looks like the RPM has an improper version number, keeping it from being easily updated via yum.  This fixes the problem.

Might it be better to use "${project.build_number}" or something similar to include this automatically?  I am not a java programmer so I'm not sure what variables are available at this point.
